### PR TITLE
Add "imported" to the list of attrs to be removed

### DIFF
--- a/pkg/tfconf/tfconf.go
+++ b/pkg/tfconf/tfconf.go
@@ -171,6 +171,7 @@ func rewriteVCLServiceResource(block *hclwrite.Block, serviceProp *prop.VCLServi
 	body.RemoveAttribute("id")
 	body.RemoveAttribute("active_version")
 	body.RemoveAttribute("cloned_version")
+	body.RemoveAttribute("imported")
 
 	// If no service level comments are set, set blank
 	// Otherwise, Terraform will set `Managed by Terraform` and cause a configuration diff


### PR DESCRIPTION
Fastly Terraform provider 2.3.3 added `imported` as a read-only attribute.
https://registry.terraform.io/providers/fastly/fastly/2.3.3/docs/resources/service_vcl