### PR TITLE
Add "force_refresh" to the list of read-only attributes

### DIFF
--- a/pkg/tfconf/tfconf.go
+++ b/pkg/tfconf/tfconf.go
@@ -172,6 +172,7 @@ func rewriteVCLServiceResource(block *hclwrite.Block, serviceProp *prop.VCLServi
 	body.RemoveAttribute("active_version")
 	body.RemoveAttribute("cloned_version")
 	body.RemoveAttribute("imported")
+	body.RemoveAttribute("force_refresh")
 
 	// If no service level comments are set, set blank
 	// Otherwise, Terraform will set `Managed by Terraform` and cause a configuration diff


### PR DESCRIPTION
terraform-provider-fastly added another read-only attribute `force_refresh` in v3.0.4. 

```
terraformify service XXXXX

( snip )

2023/02/17 16:34:11 [INFO] Running "terraform refresh" to format the state file and check errors
Error: exit status 1

Error: Value for unconfigurable attribute

  with fastly_service_vcl.service,
  on main.tf line 5, in resource "fastly_service_vcl" "service":
   5:   force_refresh      = false

Can't configure a value for "force_refresh": its value will be decided
automatically based on the result of applying this configuration.
```

This PR adds it to the list of attributes to be removed before running "terraform refresh"