### PR TITLE
Suppress command usage output on errors and update HCL cleanup

### DIFF
--- a/cmd/compute.go
+++ b/cmd/compute.go
@@ -20,6 +20,7 @@ var computeCmd = &cobra.Command{
 	Use:          "compute <service-id> <path-to-package>",
 	Short:        "Generate TF files for an existing Fastly C@E service",
 	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filter := cli.CreateLogFilter()
 		log.Printf("[INFO] CLI version: %s", getVersion())

--- a/cmd/vcl.go
+++ b/cmd/vcl.go
@@ -20,6 +20,7 @@ var vclCmd = &cobra.Command{
 	Use:          "vcl <service-id>",
 	Short:        "Generate TF files for an existing Fastly VCL service",
 	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filter := cli.CreateLogFilter()
 		log.Printf("[INFO] CLI version: %s", getVersion())

--- a/pkg/tfconf/cleanup.go
+++ b/pkg/tfconf/cleanup.go
@@ -35,12 +35,12 @@ func cleanupHCL(rawHCL string) string {
 	// Helper function to check if a given block is a supported Terraform resource block
 	isSupportedResourceBlock := func(block string) bool {
 		supportedBlocks := []string{
-			"\"fastly_service_acl_entries\"",
-			"\"fastly_service_compute\"",
-			"\"fastly_service_dictionary_items\"",
-			"\"fastly_service_dynamic_snippet_content\"",
-			"\"fastly_service_vcl\"",
-			"\"fastly_service_waf_configuration\"",
+			"fastly_service_acl_entries",
+			"fastly_service_compute",
+			"fastly_service_dictionary_items",
+			"fastly_service_dynamic_snippet_content",
+			"fastly_service_vcl",
+			"fastly_service_waf_configuration",
 		}
 
 		for _, supportedBlock := range supportedBlocks {
@@ -70,8 +70,9 @@ func cleanupHCL(rawHCL string) string {
 				// If we're not in a block, check if it's a supported resource block
 				if strings.HasPrefix(trimedText, "resource") {
 					b := strings.Fields(trimedText)[1]
+					b = strings.Trim(b, "\"")
 					if isSupportedResourceBlock(b) {
-						blocks = append(blocks, "resource")
+						blocks = append(blocks, b)
 					}
 				}
 			case 1:
@@ -105,6 +106,14 @@ func cleanupHCL(rawHCL string) string {
 
 		// Special handling for nested blocks
 		if len(blocks) > 0 {
+			if blocks[len(blocks) - 1] == "fastly_service_dynamic_snippet_content" {
+				switch {
+					case strings.HasPrefix(trimedText, "content "):
+						handleMultilineStrings(trimedText)
+						text = truncateValue(text)
+				}
+			}
+
 			if blocks[len(blocks) - 1] == "backend" {
 				switch {
 				case strings.HasSuffix(trimedText, "(sensitive value)"):

--- a/testdata/cleanup_output.hcl
+++ b/testdata/cleanup_output.hcl
@@ -154,21 +154,13 @@ resource "fastly_service_dictionary_items" "redirect_table" {
     service_id    = "7ManTUgtlSytxeXRMPYY33"
 }
 resource "fastly_service_dynamic_snippet_content" "my_dynamic_snippet_one" {
-    content    = <<-EOT
-        if ( req.url ) {
-         set req.http.my-snippet-test-header-one = "true";
-        }
-    EOT
+    content    = ""
     id         = "7ManTUgtlSytxeXRMPYY33/0c9bM9rXXNKq9iDMsmPeuY"
     service_id = "7ManTUgtlSytxeXRMPYY33"
     snippet_id = "0c9bM9rXXNKq9iDMsmPeuY"
 }
 resource "fastly_service_dynamic_snippet_content" "my_dynamic_snippet_two" {
-    content    = <<-EOT
-        if ( req.url ) {
-         set req.http.my-snippet-test-header-two = "true";
-        }
-    EOT
+    content    = ""
     id         = "7ManTUgtlSytxeXRMPYY33/2nsQvKJBGxurwIw44y6JPk"
     service_id = "7ManTUgtlSytxeXRMPYY33"
     snippet_id = "2nsQvKJBGxurwIw44y6JPk"


### PR DESCRIPTION
This PR addresses two primary changes:

    1. Suppress command usage output on errors:
        Updated cmd/compute.go and cmd/vcl.go to set SilenceUsage to true in the respective cobra.Command structs, suppressing the command usage output when an error occurs.

    2. Update HCL cleanup logic:
        Refactored the cleanupHCL function in pkg/tfconf/cleanup.go to correctly handle block names without double quotes and properly clean up nested blocks.
        Updated the test data in testdata/cleanup_output.hcl to reflect the new HCL cleanup output.