### PR TITLE
Enable interactive selection of data stores during Compute service im…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ clean:
 
 build: clean
 	go build -trimpath $(LDFLAGS) -o dist/terraformify main.go
-	@echo 'To use your locally built version of terraformify, run: export PATH=$(PWD)/dist:$$PATH'
+	@echo 'To use your locally built version of terraformify, set the PATH with the following command:'
+	@echo 'export PATH=$(PWD)/dist:$$PATH'
 
 fmt:
 	gofmt -s -w $(GOFILES)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,10 +47,11 @@ func init() {
 	// Persistent flags
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.terraformify.yaml)")
 	rootCmd.PersistentFlags().StringP("working-dir", "d", ".", "Terraform working directory")
-	rootCmd.PersistentFlags().BoolP("interactive", "i", false, "Interactively select associated resources to import")
 	rootCmd.PersistentFlags().StringP("api-key", "k", "", "Fastly API token (or via FASTLY_API_KEY)")
 	rootCmd.PersistentFlags().BoolP("skip-edit-state", "s", false, "Skip editing terraform.tfstate and leave it untouched (Note: Diffs will be detected on terraform plan/apply)")
 	rootCmd.PersistentFlags().BoolP("yes", "y", false, "Answer yes automatically to all Yes/No confirmations")
+	rootCmd.PersistentFlags().BoolP("test-mode", "t", false, "Test mode (For automated testing)")
+	rootCmd.PersistentFlags().Lookup("test-mode").Hidden = true
 
 	// Associate --token with the env ver, FASTLY_API_KEY
 	replacer := strings.NewReplacer("-", "_")

--- a/cmd/vcl.go
+++ b/cmd/vcl.go
@@ -79,6 +79,11 @@ var vclCmd = &cobra.Command{
 			return err
 		}
 
+		testMode, err := cmd.Flags().GetBool("test-mode")
+		if err != nil {
+			return err
+		}
+
 		c := cli.Config{
 			ID:            args[0],
 			ResourceName:  resourceName,
@@ -88,6 +93,7 @@ var vclCmd = &cobra.Command{
 			ManageAll:     manageAll,
 			ForceDestroy:  forceDestroy,
 			SkipEditState: skipEditState,
+			TestMode:      testMode,
 		}
 
 		return ImportVCL(c)
@@ -96,6 +102,7 @@ var vclCmd = &cobra.Command{
 
 func init() {
 	serviceCmd.AddCommand(vclCmd)
+	vclCmd.Flags().BoolP("interactive", "i", false, "Interactively select associated resources to import")
 }
 
 func ImportVCL(c cli.Config) error {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -40,10 +40,10 @@ The generated files and directories will be named after the TF resource being im
 
 ### Interactive Mode
 
-By default, the tool imports all resources associated with the service, such as ACL entries, dictionary items, WAF..etc. To interactively select which resources to import, use the `--interactive` or `-i` flag.
+By default, the tool imports all resources associated with the service, such as ACL entries, dictionary items, WAF..etc. To interactively select which resources to import, use the `--interactive` or `-i` flag. Interactive mode is only for VCL services and does not work for Compute services.
 
 ```
-terraformify service (vcl|compute) <service-id> [<path-to-package>] -i
+terraformify service vcl <service-id> -i
 ```
 
 ### Importing Specific Version
@@ -82,7 +82,8 @@ terraformify service (vcl|compute) <service-id> [<path-to-package>] -m
 
 By default, the tool updates `terraform.tfstate` directly. To disable this behavior and leave the state file untouched, use the `--skip-edit-state` or `-s` flag.
 
-**Note:** Terraform detects diffs without this behavior and `terraform apply` may result in the destruction and re-creation of associated resources, such as ACL entries and Dictionary items.
+> [!IMPORTANT]
+> This flag is intended for debugging purposes. Without updating the state file, Terraform detects diffs and `terraform apply` may result in the destruction and re-creation of associated resources, such as ACL entries and Dictionary items.
 
 ```
 terraformify service (vcl|compute) <service-id> [<path-to-package>] -s

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
@@ -22,6 +24,7 @@ type Config struct {
 	ManageAll     bool
 	ForceDestroy  bool
 	SkipEditState bool
+	TestMode      bool
 }
 
 var Bold = color.New(color.Bold).SprintFunc()
@@ -60,6 +63,39 @@ func YesNo(message string) bool {
 			return true
 		} else if response == "n" || response == "no" {
 			return false
+		}
+	}
+}
+
+// DataStoreType prompts the user to select a number for a Data Store type and returns the corresponding TF resource name.
+// 1 for Config Store, 2 for Secret Store, and 3 for KV Store. It keeps prompting if the input is invalid.
+func AskDataStoreType(resource string) string {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		BoldYellowf(os.Stderr, `"%s" - Select Data Store Type:
+	1: Config Store
+	2: Secret Store
+	3: KV Store
+	Enter number: `, resource)
+
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		response = strings.TrimSpace(response)
+		choice, _ := strconv.Atoi(response)
+
+		switch choice {
+		case 1:
+			return "fastly_configstore"
+		case 2:
+			return "fastly_secretstore"
+		case 3:
+			return "fastly_kvstore"
+		default:
+			fmt.Fprintf(os.Stderr, "\n")
 		}
 	}
 }

--- a/pkg/prop/prop.go
+++ b/pkg/prop/prop.go
@@ -271,6 +271,9 @@ func (l *LinkedResource) GetNormalizedName() string {
 func (l *LinkedResource) GetRef() string {
 	return l.GetType() + "." + l.GetNormalizedName()
 }
+func (l *LinkedResource) SetDataStoreType(t string) {
+	l.Type = t
+}
 func (l *LinkedResource) MutateType() error {
 	switch l.Type {
 	case "fastly_configstore":

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -143,6 +143,7 @@ func TestImportService(t *testing.T) {
 				Package:      packageFile,
 				Directory:    testDirPath,
 				ForceDestroy: true,
+				TestMode:     true,
 			}
 
 			if tc.resourceType == "vcl" {


### PR DESCRIPTION
- Enable interactive selection of Data stores during Compute service import.
- Remove `interactive` flag from Compute service to align with the new import flow.
- Add `test-mode` flag for automated testing
- Modify documentation to clarify the usage of the `skip-edit-state` flag and `interactive` mode.
