### PR TITLE
Update CI workflows to use latest versions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,23 +9,23 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
-      - uses: actions/checkout@v3
+          go-version: '1.22'
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.51
+          version: v1.54
           skip-cache: true
 
   test:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
-      - uses: actions/checkout@v3
+          go-version: '1.22'
+      - uses: actions/checkout@v4
       - name: Run tests
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: '1.22'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
This PR updates the CI workflows to use the latest versions of various actions and tools:

- actions/setup-go is updated from v3 to v5, and the Go version is bumped from 1.18 to 1.22.
- actions/checkout is updated from v3 to v4 in the golangci-lint.yml workflow and from v2 to v4 in the release.yml workflow.
- golangci/golangci-lint-action is updated from v3 to v4, and the version of golangci-lint is bumped from v1.51 to v1.54.
- goreleaser/goreleaser-action is updated from v2 to v5.

This PR does not introduce any changes to the application code itself. It only updates the CI configuration files.