### PR TITLE
Make package optional for Compute services

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ terraformify service vcl <service-id>
 For Compute services, provide the service ID and the path to the WASM package as arguments:
 
 ```
-terraformify service compute <service-id> <path-to-package>
+terraformify service compute <service-id> -p <path-to-package>
 ```
 
 For more detailed usage instructions, including available flags and commands, see the [Usage Documentation](docs/USAGE.md).


### PR DESCRIPTION
- Update computeCmd to make the package argument optional
- Add a new --package (-p) flag to specify the path to the package file
- Update ImportCompute function to handle cases where package is not provided
- Update TFConf.RewriteResources to add fastly_package_hash block only if package is set
- Update rewriteComputeServiceResource to set empty string for filename if package is not set